### PR TITLE
ci: fix flaky fast-tier notebook timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,14 @@ jobs:
       # nbmake executes each notebook in its own directory, so the repo-relative
       # data loads (./Logs, data/audio/...) resolve. Intentional error cells are
       # tagged `raises-exception` in the notebooks and are honored automatically.
+      #
+      # Notes on the flags:
+      #   --nbmake-timeout=1800  The Frequency Analysis tutorial has a brute-force
+      #     "DFT by correlation" demo over an 11 kHz audio chord (~2 min even on a
+      #     fast machine). On a slow/contended shared runner it can creep past the
+      #     old 900 s cap, so we give it generous headroom.
+      #   -n 2  Cap xdist at two workers. Oversubscribing a shared runner makes the
+      #     CPU-bound DFT cells slower (closer to the timeout), so we trade a little
+      #     parallelism for reliability.
       - name: Execute fast notebooks (Tutorials + StepTracker)
-        run: pytest --nbmake --nbmake-timeout=900 -n auto Tutorials/ Projects/StepTracker/
+        run: pytest --nbmake --nbmake-timeout=1800 -n 2 Tutorials/ Projects/StepTracker/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,11 @@ jobs:
       # data loads (./Logs, data/audio/...) resolve. Intentional error cells are
       # tagged `raises-exception` in the notebooks and are honored automatically.
       #
-      # Notes on the flags:
-      #   --nbmake-timeout=1800  The Frequency Analysis tutorial has a brute-force
-      #     "DFT by correlation" demo over an 11 kHz audio chord (~2 min even on a
-      #     fast machine). On a slow/contended shared runner it can creep past the
-      #     old 900 s cap, so we give it generous headroom.
-      #   -n 2  Cap xdist at two workers. Oversubscribing a shared runner makes the
-      #     CPU-bound DFT cells slower (closer to the timeout), so we trade a little
-      #     parallelism for reliability.
+      # --nbmake-timeout=1800: the Frequency Analysis tutorial has a brute-force
+      # "DFT by correlation" demo over an 11 kHz audio chord (~2 min even on a fast
+      # machine). Shared runners vary a lot (this suite has run anywhere from ~3 to
+      # ~16 min), and on a slow one that cell crept past the old 900 s cap. 1800 s
+      # gives generous headroom; -n auto keeps the suite parallel so wall time stays
+      # reasonable.
       - name: Execute fast notebooks (Tutorials + StepTracker)
-        run: pytest --nbmake --nbmake-timeout=1800 -n 2 Tutorials/ Projects/StepTracker/
+        run: pytest --nbmake --nbmake-timeout=1800 -n auto Tutorials/ Projects/StepTracker/


### PR DESCRIPTION
## Problem
The **Notebook smoke tests (fast tier)** job intermittently fails with a per-cell timeout. The culprit is a **pre-existing** cell in `Tutorials/Signals - Frequency Analysis.ipynb`: a brute-force *"DFT by correlation"* demo that sweeps ~5,500 frequencies (1 Hz step) over an 11 kHz audio chord. Its saved runtime is **~2 min** even on a fast machine; on a slow/contended GitHub runner it crept past the old **900 s** cap and timed out (PR #25's run).

Confirmed flaky: re-running the failed job on un-fixed master **passed in 3m24s**. The same suite has been observed at ~3 min, ~16 min, and ~32 min purely due to runner variance.

## Fix (CI config only — no notebook changes)
- `--nbmake-timeout=900 → 1800` — generous headroom; the ~2 min DFT cell finishes well under 1800 s even on a slow runner. **This is the real fix.**
- Kept `-n auto` (an initial pass tried `-n 2`, but that cut parallelism and pushed the suite to ~32 min on a slow runner without helping correctness).

## Optional follow-up
The underlying cell is genuinely slow. It could be made fast *and* robust by passing a coarser `xcorr_freq_step_size` to that one demo (the helper already supports it and other cells use it; at a 0–5.5 kHz axis the plot looks identical). Can do separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)